### PR TITLE
Set proper Z coordinates to gl_Position

### DIFF
--- a/graph100k.html
+++ b/graph100k.html
@@ -386,8 +386,9 @@ let shaders;
             normal = normalize(normal) * u_thickness * 0.5;
             normal.x /= u_aspect_ratio;
             if ((gl_VertexID % 2) == 1) normal *= -1.0;
-
-            gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+            
+            float line_z = float(gl_InstanceID) / u_point_count - 1.0;
+            gl_Position = vec4(0.0, 0.0, line_z, 1.0);            
             gl_Position.xy = ((gl_VertexID < 2) ? a : b) + normal;
         }`;
 
@@ -854,6 +855,7 @@ requestAnimationFrame(function frame(elapsed) {
 
     /* clear all */
     gl.clearColor(0.95, 0.95, 1.00, 1);
+    gl.clearDepth(1.0);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
     /* enable depth */


### PR DESCRIPTION
This prevents massive overdraw when zoomed out, and should look exactly the same if the graph color is opaque.

Performance difference on my machine (ryzen 7700x, radeon 6600xt):
before (~28ms frames): https://profiler.firefox.com/public/a70tf49mz88rjzwpw3pgv17ggr93tsmdjg90zq8/stack-chart/?globalTrackOrder=0&thread=1&v=10
after: (~13ms frames): https://profiler.firefox.com/public/93fg8apjw68gznhx4pb4jk0vyq2dc3y2eev5rw8/stack-chart/?globalTrackOrder=01&thread=1&v=10